### PR TITLE
Merchant bulk discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -17,6 +17,12 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(merchant.id)
   end
 
+  def destroy
+    merchant = Merchant.find(params[:merchant_id])
+    bulk_discount = BulkDiscount.find(params[:id])
+    bulk_discount.destroy
+    redirect_to merchant_bulk_discounts_path(merchant.id)
+  end
 
 private 
   def discount_params

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,6 +1,6 @@
 class BulkDiscountsController < ApplicationController
   def index
-    @bulk_discounts = Merchant.find(params[:merchant_id]).bulk_discounts
+    @merchant = Merchant.find(params[:merchant_id])
   end
 
   def show

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,5 +6,6 @@
 	<p><strong>Bulk Discount <%=index+1%>:</strong></p>
 	<p><strong> Quantity threshold:</strong> <%= discount.quantity %>, <strong>Percentage discount:</strong> <%= number_to_percentage(discount.discount*100, precision: 0) %></p>
 	<p><%= link_to "Go to This Discount", bulk_discount_path(discount.id)%></p><br>
+	<p><%= link_to 'Delete This Discount', bulk_discount_path(discount.id, merchant_id: @merchant.id), method: :delete%></p>
 	</section>
 <% end %>

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,6 +1,7 @@
 <h1>Bulk Discounts List</h1>
-<p><%=link_to 'New Bulk Discount', new_merchant_bulk_discount_path(@bulk_discounts.first.merchant_id) %></p>
-<% @bulk_discounts.each_with_index do |discount, index| %>
+
+<p><%=link_to 'New Bulk Discount', new_merchant_bulk_discount_path(@merchant.id) %></p>
+<% @merchant.bulk_discounts.each_with_index do |discount, index| %>
 	<section id = "bulk_discount-<%= discount.id %>">
 	<p><strong>Bulk Discount <%=index+1%>:</strong></p>
 	<p><strong> Quantity threshold:</strong> <%= discount.quantity %>, <strong>Percentage discount:</strong> <%= number_to_percentage(discount.discount*100, precision: 0) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,6 @@ Rails.application.routes.draw do
   resources :merchants, only: [:show] do 
     resources :bulk_discounts, only: [:index, :new, :create]
   end
-  resources :bulk_discounts, only: [:show]
+  resources :bulk_discounts, only: [:show, :destroy]
 
 end

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -47,4 +47,24 @@ RSpec.describe "merchants bulk discounts index page", type: :feature do
 
   end
 
+    it 'has a link to delete each bulk discount' do 
+      bulk_discount1 = @merchant1.bulk_discounts.create!(quantity:10, discount:0.15)
+      bulk_discount2 = @merchant1.bulk_discounts.create!(quantity:15, discount:0.2)
+
+      visit merchant_bulk_discounts_path(@merchant1.id)
+
+      expect(page).to have_content('Quantity threshold: 10, Percentage discount: 15%')
+      expect(page).to have_content('Quantity threshold: 15, Percentage discount: 20%')
+
+      within("#bulk_discount-#{bulk_discount1.id}") do 
+      
+        click_link 'Delete This Discount'
+
+        expect(current_path).to eq merchant_bulk_discounts_path(@merchant1.id)
+      end
+
+      expect(page).to_not have_content('Quantity threshold: 10, Percentage discount: 15%')
+      expect(page).to have_content('Quantity threshold: 15, Percentage discount: 20%')
+  end
+
 end


### PR DESCRIPTION
Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed
