### PR TITLE
Merchant bulk discount edit

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -17,6 +17,9 @@ class BulkDiscountsController < ApplicationController
     redirect_to merchant_bulk_discounts_path(merchant.id)
   end
 
+  def edit 
+    @bulk_discount = BulkDiscount.find(params[:id])
+  end
   def destroy
     merchant = Merchant.find(params[:merchant_id])
     bulk_discount = BulkDiscount.find(params[:id])

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -20,6 +20,14 @@ class BulkDiscountsController < ApplicationController
   def edit 
     @bulk_discount = BulkDiscount.find(params[:id])
   end
+
+  def update
+    merchant = Merchant.find(params[:merchant_id])
+    bulk_discount = BulkDiscount.find(params[:id])
+    bulk_discount.update(discount_params)
+    redirect_to merchant_bulk_discount_path(merchant.id, bulk_discount.id)
+  end
+
   def destroy
     merchant = Merchant.find(params[:merchant_id])
     bulk_discount = BulkDiscount.find(params[:id])

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>Edit Bulk Discount Info</h1>
+  <%= form_with url: merchant_bulk_discount_path(@bulk_discount.merchant.id, @bulk_discount.id), method: :patch, local: true do |form| %>
+    <p><%= form.label :quantity, "Quantity:" %></p>
+    <p><%= form.text_field :quantity, :value => @bulk_discount.quantity%></p>
+    <p><%= form.label :discount, "Discount(0.01-0.99):" %></p>
+    <p><%= form.text_field :discount, :value => @bulk_discount.discount %></p>
+    <p><%= form.submit 'Save' %></p>
+  <% end %>
+

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,2 +1,3 @@
 <p><strong>Bulk Discount Into: </strong></p>
 <p><strong> Quantity threshold:</strong> <%= @bulk_discount.quantity %>, <strong>Percentage discount:</strong> <%= number_to_percentage(@bulk_discount.discount*100, precision: 0) %></p>
+<p><%= link_to 'Edit Bulk Discount', edit_merchant_bulk_discount_path(@bulk_discount.merchant.id, @bulk_discount.id) %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   end
 
   resources :merchants, only: [:show] do 
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :edit, :destroy]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
   end
 
   resources :merchants, only: [:show] do 
-    resources :bulk_discounts, only: [:index, :show, :new, :create, :destroy]
+    resources :bulk_discounts, only: [:index, :show, :new, :create, :edit, :destroy]
   end
 
 end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "merchants bulk discounts edit page", type: :feature do
+  before(:each) do
+    @merchant1 = Merchant.create!(name: "Klein, Rempel and Jones")
+    @merchant2 = Merchant.create!(name: "Williamson Group")
+  end
+
+  it 'can edit an bulk discount' do 
+    bulk_discount1 = @merchant1.bulk_discounts.create!(quantity:10, discount:0.15)
+
+    visit merchant_bulk_discounts_path(@merchant1.id, bulk_discount1.id)
+
+    expect(page).to_not have_content(20)
+    expect(page).to_not have_content('20%')    
+    expect(page).to have_content(15)
+    expect(page).to have_content('15%')
+
+    visit edit_merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
+
+    fill_in 'quantity', with: 20
+    fill_in 'discount', with: 0.2
+
+    click_button 'Save'
+
+    expect(current_path).to eq merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
+    expect(page).to have_content(20)
+    expect(page).to have_content('20%')
+    expect(page).to_not have_content(15)
+    expect(page).to_not have_content('15%')
+  end
+
+end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "merchants bulk discounts index page", type: :feature do
+RSpec.describe "merchants bulk discounts new page", type: :feature do
   before(:each) do
     @merchant1 = Merchant.create!(name: "Klein, Rempel and Jones")
     @merchant2 = Merchant.create!(name: "Williamson Group")

--- a/spec/features/bulk_discounts/show_spec.rb
+++ b/spec/features/bulk_discounts/show_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "merchants bulk discounts index page", type: :feature do
+RSpec.describe "merchants bulk discount show page", type: :feature do
   before(:each) do
     @merchant1 = Merchant.create!(name: "Klein, Rempel and Jones")
     @merchant2 = Merchant.create!(name: "Williamson Group")
@@ -16,6 +16,16 @@ RSpec.describe "merchants bulk discounts index page", type: :feature do
     expect(page).to have_content('Quantity threshold: 10, Percentage discount: 15%')
     expect(page).to_not have_content('Quantity threshold: 15, Percentage discount: 20%')
     expect(page).to_not have_content('Quantity threshold:20, Percentage discount: 25%')
+  end
+
+  it 'has a link to edit the bulk discount' do 
+    bulk_discount1 = @merchant1.bulk_discounts.create!(quantity:10, discount:0.15)
+    
+    visit merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
+
+    click_link 'Edit Bulk Discount'
+
+    expect(current_path).to eq edit_merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
   end
 
 end


### PR DESCRIPTION
Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated