### PR TITLE
merchant invoice show page shows discounted revenue

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -2,6 +2,8 @@ class Invoice < ApplicationRecord
   belongs_to :customer
   has_many :invoice_items, dependent: :destroy
   has_many :items, through: :invoice_items
+  has_many :merchants, through: :items
+  has_many :bulk_discounts, through: :merchants
   has_many :transactions, dependent: :destroy
 
   enum status: {"cancelled" => 0, "in progress" => 1, "completed" => 2}
@@ -13,5 +15,14 @@ class Invoice < ApplicationRecord
   
   def total_revenue
     invoice_items.sum("unit_price * quantity").to_f/100
+  end
+
+  def discounted_revenue
+    discount = invoice_items.joins(:bulk_discounts)
+                                      .where('invoice_items.quantity >= bulk_discounts.quantity')
+                                      .select('invoice_items.id, max(invoice_items.unit_price * invoice_items.quantity *(bulk_discounts.discount)/100.00) as total_discount')
+                                      .group('invoice_items.id')
+                                      .sum(&:total_discount)
+    total_revenue - discount
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,6 +1,7 @@
 class InvoiceItem < ApplicationRecord
   belongs_to :invoice
   belongs_to :item
+  has_many :bulk_discounts, through: :item
 
   validates_presence_of :quantity, :unit_price, :status
   validates :quantity, numericality: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,7 @@ class Item < ApplicationRecord
   has_many :invoice_items, dependent: :destroy
   belongs_to	:merchant
   has_many :invoices, through: :invoice_items
+  has_many :bulk_discounts, through: :merchant
 
   validates_presence_of :name, :description, :unit_price, :status
   validates :unit_price, numericality: {only_integer: true}

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -5,6 +5,7 @@
 <p>Invoice Creation Date: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %></p>
 <p>Customer Name: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
 <p>Total Revenue: $<%= '%.02f' % @invoice.total_revenue %></p>
+<p>Discounted Revenue: <%= number_to_currency(@invoice.discounted_revenue, :unit =>'$') %></p>
 <h1>Item Information</h1>
 
 <% @invoice.items.each do |item| %>

--- a/spec/features/invoices/show_spec.rb
+++ b/spec/features/invoices/show_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe 'invoice show page' do
     @invoice2 = Invoice.create!(customer_id: @customer1.id, status: "in progress")
     @invoice3 = Invoice.create!(customer_id: @customer2.id, status: "in progress")
     @invoice_item1 = InvoiceItem.create!(item_id: @item1.id, invoice_id: @invoice1.id, quantity: 1, unit_price: 75100, status: "shipped",)
-    @invoice_item2 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice2.id, quantity: 3, unit_price: 200000, status: "packaged",)
-    @invoice_item3 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice2.id, quantity: 1, unit_price: 32301, status: "pending",)
-    @invoice_item4 = InvoiceItem.create!(item_id: @item4.id, invoice_id: @invoice3.id, quantity: 5, unit_price: 10000, status: "pending",)
-
+    @invoice_item2 = InvoiceItem.create!(item_id: @item2.id, invoice_id: @invoice2.id, quantity: 3, unit_price: 200000, status: "packaged")
+    @invoice_item3 = InvoiceItem.create!(item_id: @item3.id, invoice_id: @invoice2.id, quantity: 1, unit_price: 32301, status: "pending")
+    @invoice_item4 = InvoiceItem.create!(item_id: @item4.id, invoice_id: @invoice3.id, quantity: 5, unit_price: 10000, status: "pending")
   end
 
   it "displays invoice information on the invoice show page" do
@@ -60,5 +59,20 @@ RSpec.describe 'invoice show page' do
       expect(current_path).to eq("/merchants/#{@merchant1.id}/invoices/#{@invoice2.id}")
       expect(find_field('status').value).to eq('shipped')
     end
+  end
+
+  it 'displays the discounted revenue that includes the largest bulk discount applied' do 
+    merchant3 = FactoryBot.create_list(:merchant, 1)[0]
+    item5 = FactoryBot.create_list(:item, 1, merchant: merchant3)[0]
+    invoice4 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice_item5 = FactoryBot.create_list(:invoice_item, 1, item: item5, invoice: invoice4, unit_price: 1000, quantity: 15)
+    merchant3.bulk_discounts.create!(quantity: 10, discount: 0.1)
+    merchant3.bulk_discounts.create!(quantity: 15, discount: 0.2)
+
+    visit "/merchants/#{merchant3.id}/invoices/#{invoice4.id}"
+
+    expect(page).to have_content('Total Revenue: $150.00')
+    expect(page).to have_content('Discounted Revenue: $120.00')
+    expect(page).to_not have_content('Discounted Revenue: $135.00')
   end
 end

--- a/spec/models/invoice_items_spec.rb
+++ b/spec/models/invoice_items_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe InvoiceItem, type: :model do
   describe 'relationships' do
     it { should belong_to :invoice }
     it { should belong_to :item }
+    it { should have_many(:bulk_discounts).through(:item)}
   end
 
   describe 'validations' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:invoice_items) }
     it { should have_many(:items).through(:invoice_items) }
     it { should have_many(:transactions) }
+    it { should have_many(:merchants).through(:items) }
+    it { should have_many(:bulk_discounts).through(:merchants) }
+
   end
 
   describe "validations" do
@@ -29,6 +32,21 @@ RSpec.describe Invoice, type: :model do
     describe '.total_revenue' do 
       it 'calculates the total revenue on this invoice' do 
         expect(@invoice1.total_revenue).to eq(6751.00)
+      end
+    end
+
+    describe '.discounted_revenue' do 
+      it 'calculates the discounted revenue on this invoice' do 
+        merchant3 = FactoryBot.create_list(:merchant, 1)[0]
+        item5 = FactoryBot.create_list(:item, 1, merchant: merchant3)[0]
+        invoice4 = FactoryBot.create_list(:invoice, 1)[0]
+        invoice_item5 = FactoryBot.create_list(:invoice_item, 1, item: item5, invoice: invoice4, unit_price: 1000, quantity: 15)
+        invoice_item5 = FactoryBot.create_list(:invoice_item, 1, item: item5, invoice: invoice4, unit_price: 1000, quantity: 10)
+        invoice_item5 = FactoryBot.create_list(:invoice_item, 1, item: item5, invoice: invoice4, unit_price: 1000, quantity: 8)
+        merchant3.bulk_discounts.create!(quantity: 10, discount: 0.1)
+        merchant3.bulk_discounts.create!(quantity: 15, discount: 0.2)
+
+        expect(invoice4.discounted_revenue).to eq(290.0)
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Item, type: :model do
     it { should have_many :invoice_items }
     it { should belong_to :merchant }
     it { should have_many(:invoices).through(:invoice_items) }
+    it { should have_many(:bulk_discounts).through(:merchant) }
   end
 
   describe "validations" do


### PR DESCRIPTION
Merchant Invoice Show Page: Total Revenue and Discounted Revenue

As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation