### PR TITLE
holiday api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :repo_info, only: [:index, :show, :edit, :new]
 
   def repo_info
-    @facade = GithubFacade.new
+    @holiday_facade = HolidayFacade.new
   end
 end

--- a/app/facades/holiday_facade.rb
+++ b/app/facades/holiday_facade.rb
@@ -1,0 +1,20 @@
+require_relative "../services/holiday_service"
+require_relative "../poros/holiday"
+
+class HolidayFacade
+
+
+  def create_holidays
+    holidays_data.map do |data|
+      Holiday.new(data)
+    end
+  end
+
+  def service
+    @_service ||= HolidayService.new
+  end
+
+  def holidays_data
+    @_holiday_data ||=service.get_holidays
+  end
+end

--- a/app/poros/holiday.rb
+++ b/app/poros/holiday.rb
@@ -1,0 +1,9 @@
+class Holiday 
+attr_reader :name, :date
+
+	def initialize(data)
+		@name = data[:name]
+		@date = data[:date]
+	end
+
+end

--- a/app/services/holiday_service.rb
+++ b/app/services/holiday_service.rb
@@ -1,0 +1,14 @@
+require "json"
+require "httparty"
+
+class HolidayService
+
+  def get_holidays
+    get_url("https://date.nager.at/api/v3/NextPublicHolidays/US")
+  end
+
+  def get_url(url)
+    response = HTTParty.get(url)
+    json = JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,5 +1,5 @@
 <h1>Bulk Discounts List</h1>
-
+<%= render partial: '/partials/holiday_api' %>
 <p><%=link_to 'New Bulk Discount', new_merchant_bulk_discount_path(@merchant.id) %></p>
 <% @merchant.bulk_discounts.each_with_index do |discount, index| %>
 	<section id = "bulk_discount-<%= discount.id %>">

--- a/app/views/partials/_holiday_api.html.erb
+++ b/app/views/partials/_holiday_api.html.erb
@@ -1,0 +1,6 @@
+<section id = "upcoming_holidays">
+<h3> Upcoming US Holidays:</h3>
+  <p><% @holiday_facade.create_holidays[0..2].each do |holiday| %></p>
+        <p><strong><%= holiday.name %>:</strong> <%= holiday.date %> </p>
+   <%end %>
+</section>

--- a/spec/facades/holiday_facade_spec.rb
+++ b/spec/facades/holiday_facade_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe HolidayFacade do 
+	before :each do 
+		@holiday_facade = HolidayFacade.new
+	end
+
+	describe '.service' do 
+		it 'creates an instance of holidayservice' do 
+			expect(@holiday_facade.service).to be_a HolidayService
+		end
+	end
+
+	describe '.holidays_data' do 
+		it 'renders holidays_data as an array of holidays' do 
+			expect(@holiday_facade.holidays_data).to be_an Array 
+			expect(@holiday_facade.holidays_data.first.key?(:date)).to eq true
+		end
+	end
+
+	describe '.create_holidays' do 
+		it 'creates instances of holidays' do 
+			expect(@holiday_facade.create_holidays).to be_an Array 
+			expect(@holiday_facade.create_holidays.first).to be_a Holiday 
+		end
+	end
+end

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe "merchants bulk discounts edit page", type: :feature do
 
     visit merchant_bulk_discounts_path(@merchant1.id, bulk_discount1.id)
 
-    expect(page).to_not have_content(20)
+    expect(page).to_not have_content('Quantity threshold: 20')
     expect(page).to_not have_content('20%')    
-    expect(page).to have_content(15)
+    expect(page).to have_content('Quantity threshold: 10')
     expect(page).to have_content('15%')
 
     visit edit_merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
@@ -24,9 +24,9 @@ RSpec.describe "merchants bulk discounts edit page", type: :feature do
     click_button 'Save'
 
     expect(current_path).to eq merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
-    expect(page).to have_content(20)
+    expect(page).to have_content('Quantity threshold: 20')
     expect(page).to have_content('20%')
-    expect(page).to_not have_content(15)
+    expect(page).to_not have_content('Quantity threshold: 15')
     expect(page).to_not have_content('15%')
   end
 

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -67,4 +67,20 @@ RSpec.describe "merchants bulk discounts index page", type: :feature do
       expect(page).to have_content('Quantity threshold: 15, Percentage discount: 20%')
   end
 
+  it 'lists the next 3 upcoming US holidays' do 
+     visit merchant_bulk_discounts_path(@merchant1.id)
+
+     holidays_data = HolidayService.new.get_holidays
+
+     within("#upcoming_holidays") do 
+      expect(page).to have_content(holidays_data[0][:name])
+      expect(page).to have_content(holidays_data[0][:date])
+      expect(page).to have_content(holidays_data[1][:name])
+      expect(page).to have_content(holidays_data[1][:date])
+      expect(page).to have_content(holidays_data[2][:name])
+      expect(page).to have_content(holidays_data[2][:date])
+      expect(page).to_not have_content(holidays_data[3][:name])
+      expect(page).to_not have_content(holidays_data[3][:date])
+     end
+  end
 end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "merchants bulk discounts new page", type: :feature do
 
     visit merchant_bulk_discounts_path(@merchant1.id)
 
-    expect(page).to_not have_content(20)
+    expect(page).to_not have_content('Quantity threshold: 20')
     expect(page).to_not have_content('20%')
 
     visit new_merchant_bulk_discount_path(@merchant1.id)
@@ -22,7 +22,7 @@ RSpec.describe "merchants bulk discounts new page", type: :feature do
     click_button 'Submit'
 
     expect(current_path).to eq merchant_bulk_discounts_path(@merchant1.id)
-    expect(page).to have_content(20)
+    expect(page).to have_content('Quantity threshold: 20')
     expect(page).to have_content('20%')
   end
 

--- a/spec/poros/holiday_spec.rb
+++ b/spec/poros/holiday_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+
+RSpec.describe Holiday do 
+	it 'exists and has user_name and contributions' do 
+		data = {name: 'Christmas', date: '12-25-2022'}
+		holiday = Holiday.new(data)
+		expect(holiday).to be_a Holiday
+		expect(holiday.name).to eq 'Christmas'
+		expect(holiday.date).to eq '12-25-2022'
+	end
+
+
+end

--- a/spec/services/holiday_service_spec.rb
+++ b/spec/services/holiday_service_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe HolidayService do 
+	describe '.get(url) and get_holidays'  do 
+		it 'gets and parses holiday url into a hash' do 
+			holiday_url = HolidayService.new.get_url('https://date.nager.at/api/v3/NextPublicHolidays/US')
+			expect(holiday_url).to be_an Array 
+			expect(holiday_url.first.key?(:name)).to be true
+		end
+	end
+end


### PR DESCRIPTION
As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)

api: https://date.nager.at/api/v3/NextPublicHolidays/US
