### PR TITLE
Bulk discount w pending invoices

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -24,15 +24,25 @@ class BulkDiscountsController < ApplicationController
   def update
     merchant = Merchant.find(params[:merchant_id])
     bulk_discount = BulkDiscount.find(params[:id])
-    bulk_discount.update(discount_params)
-    redirect_to merchant_bulk_discount_path(merchant.id, bulk_discount.id)
+    if bulk_discount.updatable?
+      bulk_discount.update(discount_params)
+      redirect_to merchant_bulk_discount_path(merchant.id, bulk_discount.id)
+    else 
+      flash[:notice] = "Cannot update Bulk Discount due to Pending Invoices"
+      redirect_to merchant_bulk_discounts_path(merchant.id)
+    end
   end
 
   def destroy
     merchant = Merchant.find(params[:merchant_id])
     bulk_discount = BulkDiscount.find(params[:id])
-    bulk_discount.destroy
-    redirect_to merchant_bulk_discounts_path(merchant.id)
+    if bulk_discount.updatable?
+      bulk_discount.destroy
+      redirect_to merchant_bulk_discounts_path(merchant.id)
+    else 
+      flash[:notice] = "Cannot delete Bulk Discount due to Pending Invoices"
+      redirect_to merchant_bulk_discounts_path(merchant.id)
+    end
   end
 
 private 

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,6 +1,15 @@
 class BulkDiscount < ApplicationRecord
 	belongs_to :merchant
+	has_many :invoices, through: :merchant
 	validates_presence_of :quantity, :discount
 	validates :quantity, numericality: {only_integer: true, greater_than: 0} 
   	validates :discount, numericality: {greater_than_or_equal_to: 0.01, less_than_or_equal_to: 0.99}
+
+  	def updatable?
+  		pending_invoices = invoices.joins(:invoice_items)
+  									.where("invoice_items.quantity >= #{quantity}")
+  									.where(status: 1)
+  		pending_invoice_items = pending_invoices.flat_map{|invoice| invoice.invoice_items}
+  		pending_invoice_items.none?{|invoice_item| invoice_item.applied_discount == self}
+  	end
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,6 +1,8 @@
 <h1>Bulk Discounts List</h1>
-<%= render partial: '/partials/holiday_api' %>
 <p><%=link_to 'New Bulk Discount', new_merchant_bulk_discount_path(@merchant.id) %></p>
+<%= render partial: '/partials/holiday_api' %>
+
+<h4>Existing Bulk Discounts:</h4>
 <% @merchant.bulk_discounts.each_with_index do |discount, index| %>
 	<section id = "bulk_discount-<%= discount.id %>">
 	<p><strong>Bulk Discount <%=index+1%>:</strong></p>

--- a/app/views/partials/_holiday_api.html.erb
+++ b/app/views/partials/_holiday_api.html.erb
@@ -1,6 +1,7 @@
 <section id = "upcoming_holidays">
-<h3> Upcoming US Holidays:</h3>
+<h4> Upcoming US Holidays:</h4>
   <p><% @holiday_facade.create_holidays[0..2].each do |holiday| %></p>
         <p><strong><%= holiday.name %>:</strong> <%= holiday.date %> </p>
    <%end %>
 </section>
+<br>

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe BulkDiscount, type: :model do
 
   describe 'associations' do
 	it {should belong_to :merchant}
+  it {should have_many(:invoices).through(:merchant)}
+  # it {should have_many(:invoice_items).through(:invoices)}
   end
 
   describe 'validations' do
@@ -15,4 +17,26 @@ RSpec.describe BulkDiscount, type: :model do
     it { should validate_numericality_of(:discount).is_less_than_or_equal_to(0.99) }
   end
 
+  describe 'instance methods' do 
+    describe '.updatable?' do 
+      it 'returns true when there are not pending invoices' do 
+        Invoice.destroy_all
+        merchant1 = FactoryBot.create_list(:merchant,1)[0]
+        item1 = FactoryBot.create_list(:item, 1, merchant: merchant1)[0]
+        invoice1 = FactoryBot.create_list(:invoice, 1, status: 0)[0]
+        invoice2 = FactoryBot.create_list(:invoice, 1, status: 1)[0]
+        invoice3 = FactoryBot.create_list(:invoice, 1, status: 2)[0]
+        FactoryBot.create_list(:invoice_item, 1, invoice: invoice1, item: item1, quantity: 5)
+        FactoryBot.create_list(:invoice_item, 1, invoice: invoice2, item: item1, quantity: 10)
+        FactoryBot.create_list(:invoice_item, 1, invoice: invoice3, item: item1, quantity: 20)
+        bulk_discount1 = merchant1.bulk_discounts.create(quantity: 5, discount: 0.05)
+        bulk_discount2 = merchant1.bulk_discounts.create(quantity: 10, discount: 0.1)
+        bulk_discount3 = merchant1.bulk_discounts.create(quantity: 20, discount: 0.2)
+    
+        expect(bulk_discount1.updatable?).to be true
+        expect(bulk_discount2.updatable?).to be false
+        expect(bulk_discount3.updatable?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Extension: When an invoice is pending, a merchant should not be able to delete or edit a bulk discount that applies to any of their items on that invoice.