### PR TITLE
Edit create applicable discounts

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -12,9 +12,14 @@ class BulkDiscountsController < ApplicationController
   end
 
   def create
-    merchant = Merchant.find(params[:merchant_id])
-    merchant.bulk_discounts.create(discount_params)
-    redirect_to merchant_bulk_discounts_path(merchant.id)
+      merchant = Merchant.find(params[:merchant_id])
+    if BulkDiscount.applicable?(discount_params)
+      merchant.bulk_discounts.create(discount_params)
+      redirect_to merchant_bulk_discounts_path(merchant.id)
+    else 
+      flash[:notice] = "Unable to create this Bulk Discount as it is not applicable with other existing discounts!"
+      redirect_to new_merchant_bulk_discount_path(merchant.id)
+    end
   end
 
   def edit 
@@ -24,12 +29,17 @@ class BulkDiscountsController < ApplicationController
   def update
     merchant = Merchant.find(params[:merchant_id])
     bulk_discount = BulkDiscount.find(params[:id])
-    if bulk_discount.updatable?
-      bulk_discount.update(discount_params)
-      redirect_to merchant_bulk_discount_path(merchant.id, bulk_discount.id)
+    if bulk_discount.updatable? 
+      if BulkDiscount.applicable?(discount_params)
+        bulk_discount.update(discount_params)
+        redirect_to merchant_bulk_discount_path(merchant.id, bulk_discount.id)
+      else
+        flash[:notice] = "Unable to update this Bulk Discount as it is not applicable with current other discounts!"
+        redirect_to edit_merchant_bulk_discount_path(merchant.id)
+      end
     else 
       flash[:notice] = "Unable to update this Bulk Discount due to Pending Invoices!"
-      redirect_to merchant_bulk_discount_path(merchant.id, bulk_discount.id)
+      redirect_to edit_merchant_bulk_discount_path(merchant.id, bulk_discount.id)
     end
   end
 
@@ -47,7 +57,7 @@ class BulkDiscountsController < ApplicationController
 
 private 
   def discount_params
-    params.permit(:quantity, :discount)
+    params.permit(:quantity, :discount, :merchant_id)
   end
 
 end

--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -12,4 +12,18 @@ class BulkDiscount < ApplicationRecord
   		pending_invoice_items = pending_invoices.flat_map{|invoice| invoice.invoice_items}
   		pending_invoice_items.none?{|invoice_item| invoice_item.applied_discount == self}
   	end
+
+  	def self.applicable?(new_params)
+  		merchant = Merchant.find(new_params[:merchant_id])
+  		bulk_discount = merchant.bulk_discounts.create(new_params)
+  		item = merchant.items.create(name: 'item', description: 'item things', unit_price: 100)
+  		customer = Customer.create(first_name: 'cust', last_name: 'omer')
+  		invoice = Invoice.create(customer: customer)
+  		invoice_item = InvoiceItem.create(item: item, invoice: invoice, unit_price: 100, quantity: new_params[:quantity])
+  		applied = invoice_item.applied_discount == bulk_discount
+  		bulk_discount.destroy
+  		duplicate = pluck(:quantity).include?(new_params[:quantity]) && pluck(:discount).include?(new_params[:discount])
+  		result = applied && !duplicate
+  		result
+  	end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -20,9 +20,11 @@
   <p><strong>Quantity:</strong> <%=invoice_item.quantity %></p>
   <p><strong>Sold For:</strong> $<%='%.02f' % (invoice_item.unit_price.to_f/100)%></p>
   <p><strong>Status:</strong> <%= invoice_item.status %></p>
+  <section id = "invoice_item-<%= invoice_item.id %>"
   <% if invoice_item.applied_discount && @invoice.status == 'completed'%>
-    <p><%= link_to 'Applied Bulk Discount',merchant_bulk_discount_path(invoice_item.applied_discount.merchant_id, invoice_item.applied_discount.id) %></p>
+    <p><%= number_to_percentage(invoice_item.applied_discount.discount*100, precision: 0)%> discount applied</p>
     <% end %>
+  </section>
     <br>
   <br/>
 </div>

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -18,19 +18,4 @@ RSpec.describe 'admin invoices index page' do
   end
 
 
-  it 'shows a link to the applied bulk discount if applicable and when invoice is marked completed' do 
-    merchant3 = FactoryBot.create_list(:merchant, 1)[0]
-    item5 = FactoryBot.create_list(:item, 1, merchant: merchant3)[0]
-    invoice4 = FactoryBot.create_list(:invoice, 1)[0]
-    invoice_item5 = FactoryBot.create_list(:invoice_item, 1, item: item5, invoice: invoice4, unit_price: 1000, quantity: 15)[0]
-    discount1 = merchant3.bulk_discounts.create!(quantity: 10, discount: 0.1)
-    discount2 = merchant3.bulk_discounts.create!(quantity: 15, discount: 0.2)
-
-    visit "/merchants/#{merchant3.id}/invoices/#{invoice4.id}"
-
-    within("#invoice_item-#{invoice_item5.id}") do 
-      click_link 'Applied Bulk Discount'
-      expect(current_path).to eq merchant_bulk_discount_path(merchant3.id, discount2.id)
-    end
-  end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -121,4 +121,20 @@ RSpec.describe "admin invoices show page" do
     expect(page).to have_field(:status, with: "completed")
     expect(current_path).to eq("/admin/invoices/#{invoice5.id}")
   end
+
+
+  it 'shows the applied bulk discount percentageif applicable and when invoice is marked completed' do 
+    merchant3 = FactoryBot.create_list(:merchant, 1)[0]
+    item5 = FactoryBot.create_list(:item, 1, merchant: merchant3)[0]
+    invoice4 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice_item5 = FactoryBot.create_list(:invoice_item, 1, item: item5, invoice: invoice4, unit_price: 1000, quantity: 15)[0]
+    discount1 = merchant3.bulk_discounts.create!(quantity: 10, discount: 0.1)
+    discount2 = merchant3.bulk_discounts.create!(quantity: 15, discount: 0.2)
+
+    visit admin_invoice_path(invoice4.id)
+
+    within("#invoice_item-#{invoice_item5.id}") do 
+      expect(page).to have_content ("20% discount applied")
+    end
+  end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe "admin invoices show page" do
   it 'shows the applied bulk discount percentageif applicable and when invoice is marked completed' do 
     merchant3 = FactoryBot.create_list(:merchant, 1)[0]
     item5 = FactoryBot.create_list(:item, 1, merchant: merchant3)[0]
-    invoice4 = FactoryBot.create_list(:invoice, 1)[0]
+    invoice4 = FactoryBot.create_list(:invoice, 1, status: 'completed')[0]
     invoice_item5 = FactoryBot.create_list(:invoice_item, 1, item: item5, invoice: invoice4, unit_price: 1000, quantity: 15)[0]
     discount1 = merchant3.bulk_discounts.create!(quantity: 10, discount: 0.1)
     discount2 = merchant3.bulk_discounts.create!(quantity: 15, discount: 0.2)

--- a/spec/features/bulk_discounts/edit_spec.rb
+++ b/spec/features/bulk_discounts/edit_spec.rb
@@ -30,4 +30,27 @@ RSpec.describe "merchants bulk discounts edit page", type: :feature do
     expect(page).to_not have_content('15%')
   end
 
+    it 'cannot update bulk discount if it is not applicable with existing discounts' do 
+    bulk_discount1 = @merchant1.bulk_discounts.create!(quantity:10, discount:0.15)
+    bulk_discount2 = @merchant1.bulk_discounts.create!(quantity:20, discount:0.25)
+
+     visit edit_merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
+
+    fill_in 'quantity', with: 20
+    fill_in 'discount', with: 0.2
+
+    click_button 'Save'
+    expect(current_path).to eq edit_merchant_bulk_discount_path(@merchant1.id, bulk_discount1.id)
+    expect(page).to have_content('Unable to update this Bulk Discount as it is not applicable with current other discounts!')
+    visit merchant_bulk_discounts_path(@merchant1.id)
+
+    expect(page).to_not have_content('Percentage discount: 20%')
+    expect(page).to have_content('Percentage discount: 15%')
+    expect(page).to have_content('Percentage discount: 25%')
+    expect(page).to have_content('Quantity threshold: 10')
+    expect(page).to have_content('Quantity threshold: 20', count: 1)
+
+  end
+
+
 end

--- a/spec/features/bulk_discounts/new_spec.rb
+++ b/spec/features/bulk_discounts/new_spec.rb
@@ -26,4 +26,22 @@ RSpec.describe "merchants bulk discounts new page", type: :feature do
     expect(page).to have_content('20%')
   end
 
+  it 'cannot create new bulk discount if it is not applicable with existing discounts' do 
+    bulk_discount1 = @merchant1.bulk_discounts.create!(quantity:10, discount:0.15)
+
+    visit new_merchant_bulk_discount_path(@merchant1.id)
+
+    fill_in 'quantity', with: 15
+    fill_in 'discount', with: 0.10
+
+    click_button 'Submit'
+
+    expect(current_path).to eq new_merchant_bulk_discount_path(@merchant1.id)
+    expect(page).to have_content('Unable to create this Bulk Discount as it is not applicable with other existing discounts!')
+
+    visit merchant_bulk_discounts_path(@merchant1.id)
+    expect(page).to_not have_content('Quantity threshold: 15')
+    expect(page).to_not have_content('Percentage discount: 10%')
+  end
+
 end

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -39,4 +39,23 @@ RSpec.describe BulkDiscount, type: :model do
       end
     end
   end
+
+    describe 'class methods' do 
+      describe '#applicable?' do 
+          it 'checks whether the params will create an applicable discount with existing discounts' do 
+            merchant1 = FactoryBot.create_list(:merchant,1)[0]
+            item1 = FactoryBot.create_list(:item, 1, merchant: merchant1)[0]
+            BulkDiscount.destroy_all
+            bulk_discount1 = merchant1.bulk_discounts.create(quantity: 5, discount: 0.05)
+            bulk_discount2 = merchant1.bulk_discounts.create(quantity: 10, discount: 0.1)
+            bulk_discount3 = merchant1.bulk_discounts.create(quantity: 20, discount: 0.2)
+            params1 = {quantity: 15, discount: 0.1, merchant_id: merchant1.id}
+            params2 = {quantity: 15, discount: 0.2, merchant_id: merchant1.id}
+            params3 = {quantity: 20, discount: 0.2, merchant_id: merchant1.id}
+            expect(BulkDiscount.applicable?(params1)).to eq false
+            expect(BulkDiscount.applicable?(params2)).to eq true
+            expect(BulkDiscount.applicable?(params3)).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Extension 3: Merchants should not be able to create/edit bulk discounts if they already have a discount in the system that would prevent the new discount from being applied (see example 4)