### PR TITLE
create_holiday_discount

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -57,7 +57,7 @@ class BulkDiscountsController < ApplicationController
 
 private 
   def discount_params
-    params.permit(:quantity, :discount, :merchant_id)
+    params.permit(:quantity, :discount, :merchant_id, :name)
   end
 
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -5,7 +5,11 @@
 <h4>Existing Bulk Discounts:</h4>
 <% @merchant.bulk_discounts.each_with_index do |discount, index| %>
 	<section id = "bulk_discount-<%= discount.id %>">
-	<p><strong>Bulk Discount <%=index+1%>:</strong></p>
+	<% if discount.name %>
+		<p><strong><%=discount.name %> Discount:</strong></p>
+	<%else  %>
+		<p><strong>Bulk Discount <%=index+1%>:</strong></p>
+	<% end %>
 	<p><strong> Quantity threshold:</strong> <%= discount.quantity %>, <strong>Percentage discount:</strong> <%= number_to_percentage(discount.discount*100, precision: 0) %></p>
 	<p><%= link_to "Go to This Discount", merchant_bulk_discount_path(@merchant.id, discount.id)%>
 	<%= link_to 'Delete This Discount', merchant_bulk_discount_path(@merchant.id, discount.id), method: :delete%></p>

--- a/app/views/bulk_discounts/new.html.erb
+++ b/app/views/bulk_discounts/new.html.erb
@@ -1,9 +1,5 @@
-<h1>New Bulk Discount for <%= @merchant.name %></h1>
-  <%= form_with url: merchant_bulk_discounts_path(@merchant.id), method: :post, local: true do |form| %>
-    <p><%= form.label :quantity, "Quantity:" %></p>
-    <p><%= form.text_field :quantity %></p>
-    <p><%= form.label :discount, "Discount(0.01-0.99):" %></p>
-    <p><%= form.text_field :discount %></p>
-    <p><%= form.submit 'Submit' %></p>
-  <% end %>
-
+<% if params[:name] %>
+  <%= render partial: '/partials/new_holiday_discount' %>
+<% else  %>
+  <%= render partial: '/partials/new_bulk_discount' %>
+<% end %>

--- a/app/views/partials/_holiday_api.html.erb
+++ b/app/views/partials/_holiday_api.html.erb
@@ -1,7 +1,11 @@
 <section id = "upcoming_holidays">
 <h4> Upcoming US Holidays:</h4>
-  <p><% @holiday_facade.create_holidays[0..2].each do |holiday| %></p>
-        <p><strong><%= holiday.name %>:</strong> <%= holiday.date %> </p>
+  <p><% @holiday_facade.create_holidays[0..2].each_with_index do |holiday, index| %></p>
+
+  <section id = "holiday-<%= index+1%>">
+        <p><strong><%= holiday.name %>:</strong> <%= holiday.date %> 
+        <%=link_to 'Create Holiday Discount', new_merchant_bulk_discount_path(@merchant.id, name: holiday.name) %></p>
+  </section>
    <%end %>
 </section>
 <br>

--- a/app/views/partials/_new_bulk_discount.html.erb
+++ b/app/views/partials/_new_bulk_discount.html.erb
@@ -1,0 +1,9 @@
+<h1>New Bulk Discount for <%= @merchant.name %></h1>
+  <%= form_with url: merchant_bulk_discounts_path(@merchant.id), method: :post, local: true do |form| %>
+    <p><%= form.label :quantity, "Quantity:" %></p>
+    <p><%= form.text_field :quantity %></p>
+    <p><%= form.label :discount, "Discount(0.01-0.99):" %></p>
+    <p><%= form.text_field :discount %></p>
+    <p><%= form.submit 'Submit' %></p>
+  <% end %>
+

--- a/app/views/partials/_new_holiday_discount.html.erb
+++ b/app/views/partials/_new_holiday_discount.html.erb
@@ -1,0 +1,11 @@
+<h1>New Holiday Discount for <%= @merchant.name %></h1>
+  <%= form_with url: merchant_bulk_discounts_path(@merchant.id), method: :post, local: true do |form| %>
+    <p><%= form.label :name, "Discount Name:" %></p>
+    <p><%= form.text_field :name, :value =>  "#{params[:name]}"%></p>
+    <p><%= form.label :quantity, "Quantity:"%></p>
+    <p><%= form.text_field :quantity,  :value => '2'  %></p>
+    <p><%= form.label :discount, "Discount(0.01-0.99):"  %></p>
+    <p><%= form.text_field :discount,  :value => '0.3'%></p>
+    <p><%= form.submit 'Submit' %></p>
+  <% end %>
+

--- a/db/migrate/20220424172057_add_name_to_bulk_discounts.rb
+++ b/db/migrate/20220424172057_add_name_to_bulk_discounts.rb
@@ -1,0 +1,5 @@
+class AddNameToBulkDiscounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bulk_discounts, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_23_160248) do
+ActiveRecord::Schema.define(version: 2022_04_24_172057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2022_04_23_160248) do
     t.bigint "merchant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
     t.index ["merchant_id"], name: "index_bulk_discounts_on_merchant_id"
   end
 

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -83,4 +83,26 @@ RSpec.describe "merchants bulk discounts index page", type: :feature do
       expect(page).to_not have_content(holidays_data[3][:date])
      end
   end
+
+  it 'has a link next to each holiday to create a holiday discount' do 
+    visit merchant_bulk_discounts_path(@merchant1.id)
+
+     holidays_data = HolidayService.new.get_holidays
+
+     within("#upcoming_holidays") do 
+      within("#holiday-1") do 
+        click_link 'Create Holiday Discount'
+
+        expect(current_path).to eq new_merchant_bulk_discount_path(@merchant1.id)
+        
+      end
+     end
+
+
+        fill_in 'quantity', with: 15
+        fill_in 'discount', with: 0.10
+        
+        click_button 'Submit'
+        expect(current_path).to eq merchant_bulk_discounts_path(@merchant1.id)
+  end
 end


### PR DESCRIPTION
As a merchant,
when I visit the discounts index page,
In the Holiday Discounts section, I see a `create discount` button next to each of the 3 upcoming holidays.
When I click on the button I am taken to a new discount form that has the form fields auto populated with the following:

Discount name: <name of holiday> discount
Percentage Discount: 30
Quantity Threshold: 2

I can leave the information as is, or modify it before saving.
I should be redirected to the discounts index page where I see the newly created discount added to the list of discounts.