### PR TITLE
view holiday discount

### DIFF
--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -13,6 +13,7 @@ class BulkDiscount < ApplicationRecord
   		pending_invoice_items.none?{|invoice_item| invoice_item.applied_discount == self}
   	end
 
+
   	def self.applicable?(new_params)
   		merchant = Merchant.find(new_params[:merchant_id])
   		bulk_discount = merchant.bulk_discounts.create(new_params)
@@ -25,5 +26,13 @@ class BulkDiscount < ApplicationRecord
   		duplicate = pluck(:quantity).include?(new_params[:quantity]) && pluck(:discount).include?(new_params[:discount])
   		result = applied && !duplicate
   		result
+  	end
+
+  	def self.find_holiday_discount_id(holiday_name)
+  		if find_by(name: holiday_name)
+  			find_by(name: holiday_name).id
+  		else 
+  			nil 
+  		end
   	end
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -6,7 +6,7 @@
 <% @merchant.bulk_discounts.each_with_index do |discount, index| %>
 	<section id = "bulk_discount-<%= discount.id %>">
 	<% if discount.name %>
-		<p><strong><%=discount.name %> Discount:</strong></p>
+		<p><strong>Bulk Discount <%=index+1%>: <%=discount.name %> Discount:</strong></p>
 	<%else  %>
 		<p><strong>Bulk Discount <%=index+1%>:</strong></p>
 	<% end %>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,3 +1,7 @@
-<p><strong>Bulk Discount Into: </strong></p>
+<% if @bulk_discount.name %>
+	<p><strong><%=  @bulk_discount.name %> Discount</strong>
+<% else %>
+	<p><strong>Bulk Discount Into: </strong></p>
+<% end %>
 <p><strong> Quantity threshold:</strong> <%= @bulk_discount.quantity %>, <strong>Percentage discount:</strong> <%= number_to_percentage(@bulk_discount.discount*100, precision: 0) %></p>
 <p><%= link_to 'Edit Bulk Discount', edit_merchant_bulk_discount_path(@bulk_discount.merchant.id, @bulk_discount.id) %></p>

--- a/app/views/partials/_holiday_api.html.erb
+++ b/app/views/partials/_holiday_api.html.erb
@@ -4,7 +4,11 @@
 
   <section id = "holiday-<%= index+1%>">
         <p><strong><%= holiday.name %>:</strong> <%= holiday.date %> 
+          <% if BulkDiscount.find_holiday_discount_id(holiday.name) %>
+            <%=link_to 'View Holiday Discount', merchant_bulk_discount_path(@merchant.id, BulkDiscount.find_holiday_discount_id(holiday.name)) %></p>
+          <% else %>
         <%=link_to 'Create Holiday Discount', new_merchant_bulk_discount_path(@merchant.id, name: holiday.name) %></p>
+        <%end %>
   </section>
    <%end %>
 </section>

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -105,4 +105,38 @@ RSpec.describe "merchants bulk discounts index page", type: :feature do
         click_button 'Submit'
         expect(current_path).to eq merchant_bulk_discounts_path(@merchant1.id)
   end
+
+  it 'shows a link to view holiday discount and no link to create if holiday discount has been created' do 
+
+      visit merchant_bulk_discounts_path(@merchant1.id)
+
+     holidays_data = HolidayService.new.get_holidays
+
+     within("#upcoming_holidays") do 
+      within("#holiday-1") do 
+        click_link 'Create Holiday Discount'
+
+        expect(current_path).to eq new_merchant_bulk_discount_path(@merchant1.id)
+        
+      end
+     end
+
+
+    fill_in 'quantity', with: 15
+    fill_in 'discount', with: 0.10
+    
+    click_button 'Submit'
+    expect(current_path).to eq merchant_bulk_discounts_path(@merchant1.id)
+    bulk_discount_id = BulkDiscount.last.id
+     within("#upcoming_holidays") do 
+        within("#holiday-1") do 
+          expect(page).to_not have_link 'Create Holiday Discount'
+          expect(page).to have_link 'View Holiday Discount'
+        
+          click_link 'View Holiday Discount'
+
+          expect(current_path).to eq merchant_bulk_discount_path(@merchant1.id, bulk_discount_id)
+        end
+      end
+  end
 end

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -57,5 +57,13 @@ RSpec.describe BulkDiscount, type: :model do
             expect(BulkDiscount.applicable?(params3)).to eq false
       end
     end
+
+    describe '#find_holiday_discount_id' do 
+      it 'returns holiday discount id if found' do 
+          merchant1 = FactoryBot.create_list(:merchant,1)[0]
+          bulk_discount1 = merchant1.bulk_discounts.create(name: 'Christmas', quantity: 5, discount: 0.05)
+          expect(BulkDiscount.find_holiday_discount_id('Christmas')).to eq(bulk_discount1.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
View a Holiday Discount

As a merchant (if I have created a holiday discount for a specific holiday),
when I visit the discount index page,
within the `Upcoming Holidays` section I should not see the button to 'create a discount' next to that holiday,
instead I should see a `view discount` link.
When I click the link I am taken to the discount show page for that holiday discount.